### PR TITLE
chore(portfolio): update dependencies in package.json and package-lock.json

### DIFF
--- a/portfolio/web/e2e/components.spec.ts
+++ b/portfolio/web/e2e/components.spec.ts
@@ -119,30 +119,12 @@ test.describe('Components page', () => {
       await page.waitForLoadState('domcontentloaded');
       await page.waitForLoadState('networkidle');
 
-      // Cliquer sur tous les boutons avec un délai entre chaque
+      // Cliquer sur tous les boutons et vérifier chaque toast immédiatement
       for (const type of toastTypes) {
         const button = page.getByTestId(`show${type}Toast`);
         await button.click();
 
         // Attendre que le toast soit créé et devienne visible
-        await page.waitForSelector(`.toast--${type.toLowerCase()}.toast--cloned`, {
-          state: 'attached',
-          timeout: 15000
-        });
-
-        // Attendre que la classe toast--visible soit ajoutée
-        await page.waitForFunction(
-          (type) => {
-            const toast = document.querySelector(`.toast--${type.toLowerCase()}.toast--cloned`);
-            return toast && toast.classList.contains('toast--visible');
-          },
-          type.toLowerCase(),
-          { timeout: 15000 }
-        );
-      }
-
-      // Vérifier que tous les toasts sont visibles
-      for (const type of toastTypes) {
         const toast = page.locator(`.toast--${type.toLowerCase()}.toast--cloned`).first();
         await expect(toast).toBeVisible({ timeout: 15000 });
         await expect(toast).toHaveClass(new RegExp(`toast--${type.toLowerCase()}.*toast--visible`), { timeout: 15000 });

--- a/portfolio/web/e2e/contact.spec.ts
+++ b/portfolio/web/e2e/contact.spec.ts
@@ -8,13 +8,13 @@ test.describe('Contact Form', () => {
 
   test('should show validation errors for empty required fields', async ({ page }) => {
     // Attendre que le formulaire soit chargé
-    await page.waitForSelector('[data-testid="contact-submit"]', { state: 'visible', timeout: 10000 });
+    await page.waitForSelector('[data-testid="contact-submit"]', { state: 'visible', timeout: 10_000 });
 
     // Click submit without filling any fields
     await page.getByTestId('contact-submit').click();
 
     // Check for error messages with increased timeout
-    await page.waitForSelector('.error-message', { state: 'visible', timeout: 10000 });
+    await page.waitForSelector('.error-message', { state: 'visible', timeout: 10_000 });
     const errorMessages = await page.locator('.error-message').all();
     expect(errorMessages).toHaveLength(4); // name, email, subject, message
   });
@@ -35,8 +35,8 @@ test.describe('Contact Form', () => {
     await expect(emailContainer).toHaveClass(/error/, { timeout: 5000 });
 
     // Check for email error message with increased timeout
-    const emailError = await page.locator('.error-message').filter({ hasText: /email.*valide/i });
-    await expect(emailError).toBeVisible({ timeout: 15000 });
+    const emailError = page.locator('.error-message').filter({ hasText: /email.*valide/i });
+    await expect(emailError).toBeVisible({ timeout: 15_000 });
   });
 
   test('should submit form successfully and show success toast', async ({ page }) => {
@@ -52,7 +52,7 @@ test.describe('Contact Form', () => {
     // Attendre que le formulaire soit complètement chargé
     await page.waitForSelector('[data-testid="contact-submit"]', {
       state: 'visible',
-      timeout: 30000
+      timeout: 30_000
     });
 
     // Fill form with valid data
@@ -73,27 +73,27 @@ test.describe('Contact Form', () => {
     // Attendre que le toast soit créé et visible avec un timeout plus long
     await page.waitForSelector('.toast--success.toast--cloned', {
       state: 'attached',
-      timeout: 30000
+      timeout: 30_000
     });
 
     // Attendre que la classe toast--visible soit ajoutée
     await page.waitForFunction(
       () => {
         const toast = document.querySelector('.toast--success.toast--cloned');
-        return toast && toast.classList.contains('toast--visible');
+        return toast?.classList.contains('toast--visible');
       },
-      { timeout: 30000 }
+      { timeout: 30_000 }
     );
 
     const successToast = page.locator('.toast--success.toast--cloned').first();
-    await expect(successToast).toBeVisible({ timeout: 30000 });
-    await expect(successToast).toHaveClass(/toast--success.*toast--visible/, { timeout: 30000 });
+    await expect(successToast).toBeVisible({ timeout: 30_000 });
+    await expect(successToast).toHaveClass(/toast--success.*toast--visible/, { timeout: 30_000 });
 
     // Verify form was reset with longer timeout
-    await expect(page.getByTestId('contact-name')).toHaveValue('', { timeout: 15000 });
-    await expect(page.getByTestId('contact-email')).toHaveValue('', { timeout: 15000 });
-    await expect(page.getByTestId('contact-subject')).toHaveValue('', { timeout: 15000 });
-    await expect(page.getByTestId('contact-message')).toHaveValue('', { timeout: 15000 });
+    await expect(page.getByTestId('contact-name')).toHaveValue('', { timeout: 15_000 });
+    await expect(page.getByTestId('contact-email')).toHaveValue('', { timeout: 15_000 });
+    await expect(page.getByTestId('contact-subject')).toHaveValue('', { timeout: 15_000 });
+    await expect(page.getByTestId('contact-message')).toHaveValue('', { timeout: 15_000 });
   });
 
   test('should show error toast when submission fails', async ({ page }) => {
@@ -129,12 +129,12 @@ test.describe('Contact Form', () => {
     // Attendre que le toast soit créé et visible
     await page.waitForSelector('.toast--error.toast--cloned.toast--visible', {
       state: 'visible',
-      timeout: 15000
+      timeout: 15_000
     });
 
     // Vérifier que le toast est visible
     const toast = page.locator('.toast--error.toast--cloned.toast--visible').first();
-    await expect(toast).toBeVisible({ timeout: 15000 });
+    await expect(toast).toBeVisible({ timeout: 15_000 });
 
     // Verify form was not reset
     await expect(page.getByTestId('contact-name')).toHaveValue('Test User');
@@ -155,7 +155,7 @@ test.describe('Contact Form Validation', () => {
             while (retries < 3) {
                 try {
                     await page.goto('/contact', {
-                        timeout: 30000,
+                        timeout: 30_000,
                         waitUntil: 'networkidle'
                     });
                     break;

--- a/portfolio/web/e2e/rss.spec.ts
+++ b/portfolio/web/e2e/rss.spec.ts
@@ -37,7 +37,7 @@ test.describe('RSS Page', () => {
             while (retries < 3) {
                 try {
                     await page.goto('/rss', {
-                        timeout: 30000,
+                        timeout: 30_000,
                         waitUntil: 'networkidle'
                     });
                     break;
@@ -62,18 +62,18 @@ test.describe('RSS Page', () => {
 
         // Vérifier que le titre de la page est correct
         const title = page.getByRole('heading', { name: 'Mes flux RSS favoris' });
-        await expect(title).toBeVisible({ timeout: 30000 });
+        await expect(title).toBeVisible({ timeout: 30_000 });
 
         // Vérifier qu'il y a 9 articles avec un timeout plus long
         const articles = page.locator('.articles-grid article');
-        await expect(articles).toHaveCount(9, { timeout: 30000 });
+        await expect(articles).toHaveCount(9, { timeout: 30_000 });
 
         // Vérifier que chaque article a les éléments requis avec un timeout plus long
         const firstArticle = articles.first();
-        await expect(firstArticle.locator('img')).toBeVisible({ timeout: 30000 });
-        await expect(firstArticle.locator('h3')).toBeVisible({ timeout: 30000 });
-        await expect(firstArticle.locator('a')).toBeVisible({ timeout: 30000 });
-        await expect(firstArticle.locator('.text-sm')).toBeVisible({ timeout: 30000 });
+        await expect(firstArticle.locator('img')).toBeVisible({ timeout: 30_000 });
+        await expect(firstArticle.locator('h3')).toBeVisible({ timeout: 30_000 });
+        await expect(firstArticle.locator('a')).toBeVisible({ timeout: 30_000 });
+        await expect(firstArticle.locator('.text-sm')).toBeVisible({ timeout: 30_000 });
     });
 
     test('should load more articles when clicking load more button', async ({ page }) => {
@@ -83,22 +83,22 @@ test.describe('RSS Page', () => {
 
         // Compter le nombre initial d'articles avec un timeout plus long
         const articles = page.locator('.articles-grid article');
-        await expect(articles).toHaveCount(9, { timeout: 30000 });
+        await expect(articles).toHaveCount(9, { timeout: 30_000 });
 
         // Cliquer sur le bouton "Charger plus"
         const loadMoreBtn = page.locator('#loadMore');
-        await expect(loadMoreBtn).toBeVisible({ timeout: 30000 });
+        await expect(loadMoreBtn).toBeVisible({ timeout: 30_000 });
         await loadMoreBtn.click();
 
         // Attendre que les nouveaux articles soient chargés avec un timeout plus long
-        await expect(articles).toHaveCount(18, { timeout: 30000 });
+        await expect(articles).toHaveCount(18, { timeout: 30_000 });
 
         // Vérifier que les nouveaux articles sont correctement formatés avec un timeout plus long
         const lastArticle = articles.last();
-        await expect(lastArticle.locator('img')).toBeVisible({ timeout: 30000 });
-        await expect(lastArticle.locator('h3')).toBeVisible({ timeout: 30000 });
-        await expect(lastArticle.locator('a')).toBeVisible({ timeout: 30000 });
-        await expect(lastArticle.locator('.text-sm')).toBeVisible({ timeout: 30000 });
+        await expect(lastArticle.locator('img')).toBeVisible({ timeout: 30_000 });
+        await expect(lastArticle.locator('h3')).toBeVisible({ timeout: 30_000 });
+        await expect(lastArticle.locator('a')).toBeVisible({ timeout: 30_000 });
+        await expect(lastArticle.locator('.text-sm')).toBeVisible({ timeout: 30_000 });
     });
 
     test('should handle empty response gracefully', async ({ page }) => {

--- a/portfolio/web/package-lock.json
+++ b/portfolio/web/package-lock.json
@@ -6187,16 +6187,17 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "bin": {
-                "prettier": "bin-prettier.js"
+                "prettier": "bin/prettier.cjs"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -8387,6 +8388,22 @@
             },
             "optionalDependencies": {
                 "prettier": "2.8.7"
+            }
+        },
+        "node_modules/yaml-language-server/node_modules/prettier": {
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "prettier": "bin-prettier.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/yaml-language-server/node_modules/request-light": {

--- a/portfolio/web/package-lock.json
+++ b/portfolio/web/package-lock.json
@@ -9,11 +9,11 @@
             "version": "0.0.1",
             "dependencies": {
                 "@astrojs/check": "^0.9.4",
-                "@astrojs/mdx": "^4.0.6",
+                "@astrojs/mdx": "^4.0.7",
                 "@astrojs/sitemap": "^3.2.1",
-                "@astrojs/tailwind": "^5.1.4",
+                "@astrojs/tailwind": "^5.1.5",
                 "@fortawesome/fontawesome-free": "^6.7.2",
-                "astro": "^5.1.7",
+                "astro": "^5.1.8",
                 "astro-i18next": "^1.0.0-beta.21",
                 "tailwindcss": "^3.4.17",
                 "three": "^0.172.0"
@@ -55,34 +55,6 @@
             },
             "peerDependencies": {
                 "typescript": "^5.0.0"
-            }
-        },
-        "node_modules/@astrojs/check/node_modules/chokidar": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-            "license": "MIT",
-            "dependencies": {
-                "readdirp": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 14.16.0"
-            },
-            "funding": {
-                "url": "https://paulmillr.com/funding/"
-            }
-        },
-        "node_modules/@astrojs/check/node_modules/readdirp": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
-            "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 14.18.0"
-            },
-            "funding": {
-                "type": "individual",
-                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@astrojs/compiler": {
@@ -166,9 +138,9 @@
             }
         },
         "node_modules/@astrojs/mdx": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.0.6.tgz",
-            "integrity": "sha512-ADLYzHrJeIIyXk6grCBr6TmHtM1buXJ/84ulwuZrte8liI0/iQSujeOjzW0/GKgh1RBBGpg1/mopbkn1sPGz5w==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/@astrojs/mdx/-/mdx-4.0.7.tgz",
+            "integrity": "sha512-d3PopBTbbCoX3QOmSLYXW6YCZ0dkhNaeP9/Liz9BhEekflMc9IvBjbtNFf1WCEatsl4LLGftyDisfMM3F3LGMA==",
             "license": "MIT",
             "dependencies": {
                 "@astrojs/markdown-remark": "6.0.2",
@@ -216,13 +188,13 @@
             }
         },
         "node_modules/@astrojs/tailwind": {
-            "version": "5.1.4",
-            "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-5.1.4.tgz",
-            "integrity": "sha512-EJ3uoTZZr0RYwTrVS2HgYN0+VbXvg7h87AtwpD5OzqS3GyMwRmzfOwHfORTxoWGQRrY9k/Fi+Awk60kwpvRL5Q==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-5.1.5.tgz",
+            "integrity": "sha512-1diguZEau7FZ9vIjzE4BwavGdhD3+JkdS8zmibl1ene+EHgIU5hI0NMgRYG3yea+Niaf7cyMwjeWeLvzq/maxg==",
             "license": "MIT",
             "dependencies": {
                 "autoprefixer": "^10.4.20",
-                "postcss": "^8.4.49",
+                "postcss": "^8.5.1",
                 "postcss-load-config": "^4.0.2"
             },
             "peerDependencies": {
@@ -1409,9 +1381,9 @@
             "license": "MIT"
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
-            "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.31.0.tgz",
+            "integrity": "sha512-9NrR4033uCbUBRgvLcBrJofa2KY9DzxL2UKZ1/4xA/mnTNyhZCWBuD8X3tPm1n4KxcgaraOYgrFKSgwjASfmlA==",
             "cpu": [
                 "arm"
             ],
@@ -1422,9 +1394,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
-            "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.31.0.tgz",
+            "integrity": "sha512-iBbODqT86YBFHajxxF8ebj2hwKm1k8PTBQSojSt3d1FFt1gN+xf4CowE47iN0vOSdnd+5ierMHBbu/rHc7nq5g==",
             "cpu": [
                 "arm64"
             ],
@@ -1435,9 +1407,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
-            "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.31.0.tgz",
+            "integrity": "sha512-WHIZfXgVBX30SWuTMhlHPXTyN20AXrLH4TEeH/D0Bolvx9PjgZnn4H677PlSGvU6MKNsjCQJYczkpvBbrBnG6g==",
             "cpu": [
                 "arm64"
             ],
@@ -1448,9 +1420,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
-            "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.31.0.tgz",
+            "integrity": "sha512-hrWL7uQacTEF8gdrQAqcDy9xllQ0w0zuL1wk1HV8wKGSGbKPVjVUv/DEwT2+Asabf8Dh/As+IvfdU+H8hhzrQQ==",
             "cpu": [
                 "x64"
             ],
@@ -1461,9 +1433,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
-            "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.31.0.tgz",
+            "integrity": "sha512-S2oCsZ4hJviG1QjPY1h6sVJLBI6ekBeAEssYKad1soRFv3SocsQCzX6cwnk6fID6UQQACTjeIMB+hyYrFacRew==",
             "cpu": [
                 "arm64"
             ],
@@ -1474,9 +1446,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
-            "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.31.0.tgz",
+            "integrity": "sha512-pCANqpynRS4Jirn4IKZH4tnm2+2CqCNLKD7gAdEjzdLGbH1iO0zouHz4mxqg0uEMpO030ejJ0aA6e1PJo2xrPA==",
             "cpu": [
                 "x64"
             ],
@@ -1487,9 +1459,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
-            "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.31.0.tgz",
+            "integrity": "sha512-0O8ViX+QcBd3ZmGlcFTnYXZKGbFu09EhgD27tgTdGnkcYXLat4KIsBBQeKLR2xZDCXdIBAlWLkiXE1+rJpCxFw==",
             "cpu": [
                 "arm"
             ],
@@ -1500,9 +1472,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
-            "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.31.0.tgz",
+            "integrity": "sha512-w5IzG0wTVv7B0/SwDnMYmbr2uERQp999q8FMkKG1I+j8hpPX2BYFjWe69xbhbP6J9h2gId/7ogesl9hwblFwwg==",
             "cpu": [
                 "arm"
             ],
@@ -1513,9 +1485,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
-            "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.31.0.tgz",
+            "integrity": "sha512-JyFFshbN5xwy6fulZ8B/8qOqENRmDdEkcIMF0Zz+RsfamEW+Zabl5jAb0IozP/8UKnJ7g2FtZZPEUIAlUSX8cA==",
             "cpu": [
                 "arm64"
             ],
@@ -1526,9 +1498,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
-            "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.31.0.tgz",
+            "integrity": "sha512-kpQXQ0UPFeMPmPYksiBL9WS/BDiQEjRGMfklVIsA0Sng347H8W2iexch+IEwaR7OVSKtr2ZFxggt11zVIlZ25g==",
             "cpu": [
                 "arm64"
             ],
@@ -1539,9 +1511,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
-            "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.31.0.tgz",
+            "integrity": "sha512-pMlxLjt60iQTzt9iBb3jZphFIl55a70wexvo8p+vVFK+7ifTRookdoXX3bOsRdmfD+OKnMozKO6XM4zR0sHRrQ==",
             "cpu": [
                 "loong64"
             ],
@@ -1552,9 +1524,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
-            "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.31.0.tgz",
+            "integrity": "sha512-D7TXT7I/uKEuWiRkEFbed1UUYZwcJDU4vZQdPTcepK7ecPhzKOYk4Er2YR4uHKme4qDeIh6N3XrLfpuM7vzRWQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1565,9 +1537,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
-            "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.31.0.tgz",
+            "integrity": "sha512-wal2Tc8O5lMBtoePLBYRKj2CImUCJ4UNGJlLwspx7QApYny7K1cUYlzQ/4IGQBLmm+y0RS7dwc3TDO/pmcneTw==",
             "cpu": [
                 "riscv64"
             ],
@@ -1578,9 +1550,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
-            "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.31.0.tgz",
+            "integrity": "sha512-O1o5EUI0+RRMkK9wiTVpk2tyzXdXefHtRTIjBbmFREmNMy7pFeYXCFGbhKFwISA3UOExlo5GGUuuj3oMKdK6JQ==",
             "cpu": [
                 "s390x"
             ],
@@ -1591,9 +1563,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
-            "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.31.0.tgz",
+            "integrity": "sha512-zSoHl356vKnNxwOWnLd60ixHNPRBglxpv2g7q0Cd3Pmr561gf0HiAcUBRL3S1vPqRC17Zo2CX/9cPkqTIiai1g==",
             "cpu": [
                 "x64"
             ],
@@ -1604,9 +1576,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
-            "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.31.0.tgz",
+            "integrity": "sha512-ypB/HMtcSGhKUQNiFwqgdclWNRrAYDH8iMYH4etw/ZlGwiTVxBz2tDrGRrPlfZu6QjXwtd+C3Zib5pFqID97ZA==",
             "cpu": [
                 "x64"
             ],
@@ -1617,9 +1589,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
-            "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.31.0.tgz",
+            "integrity": "sha512-JuhN2xdI/m8Hr+aVO3vspO7OQfUFO6bKLIRTAy0U15vmWjnZDLrEgCZ2s6+scAYaQVpYSh9tZtRijApw9IXyMw==",
             "cpu": [
                 "arm64"
             ],
@@ -1630,9 +1602,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
-            "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.31.0.tgz",
+            "integrity": "sha512-U1xZZXYkvdf5MIWmftU8wrM5PPXzyaY1nGCI4KI4BFfoZxHamsIe+BtnPLIvvPykvQWlVbqUXdLa4aJUuilwLQ==",
             "cpu": [
                 "ia32"
             ],
@@ -1643,9 +1615,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
-            "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.31.0.tgz",
+            "integrity": "sha512-ul8rnCsUumNln5YWwz0ted2ZHFhzhRRnkpBZ+YRuHoRAlUji9KChpOUOndY7uykrPEPXVbHLlsdo6v5yXo/TXw==",
             "cpu": [
                 "x64"
             ],
@@ -1656,62 +1628,62 @@
             ]
         },
         "node_modules/@shikijs/core": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.27.2.tgz",
-            "integrity": "sha512-ns1dokDr0KE1lQ9mWd4rqaBkhSApk0qGCK1+lOqwnkQSkVZ08UGqXj1Ef8dAcTMZNFkN6PSNjkL5TYNX7pyPbQ==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.1.tgz",
+            "integrity": "sha512-Mo1gGGkuOYjDu5H8YwzmOuly9vNr8KDVkqj9xiKhhhFS8jisAtDSEWB9hzqRHLVQgFdA310e8XRJcW4tYhRB2A==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/engine-javascript": "1.27.2",
-                "@shikijs/engine-oniguruma": "1.27.2",
-                "@shikijs/types": "1.27.2",
+                "@shikijs/engine-javascript": "1.29.1",
+                "@shikijs/engine-oniguruma": "1.29.1",
+                "@shikijs/types": "1.29.1",
                 "@shikijs/vscode-textmate": "^10.0.1",
                 "@types/hast": "^3.0.4",
                 "hast-util-to-html": "^9.0.4"
             }
         },
         "node_modules/@shikijs/engine-javascript": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.27.2.tgz",
-            "integrity": "sha512-0JB7U5vJc16NShBdxv9hSSJYSKX79+32O7F4oXIxJLdYfomyFvx4B982ackUI9ftO9T3WwagkiiD3nOxOOLiGA==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.1.tgz",
+            "integrity": "sha512-Hpi8k9x77rCQ7F/7zxIOUruNkNidMyBnP5qAGbLFqg4kRrg1HZhkB8btib5EXbQWTtLb5gBHOdBwshk20njD7Q==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.27.2",
+                "@shikijs/types": "1.29.1",
                 "@shikijs/vscode-textmate": "^10.0.1",
-                "oniguruma-to-es": "^2.0.0"
+                "oniguruma-to-es": "^2.2.0"
             }
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.27.2.tgz",
-            "integrity": "sha512-FZYKD1KN7srvpkz4lbGLOYWlyDU4Rd+2RtuKfABTkafAPOFr+J6umfIwY/TzOQqfNtWjL7SAwPAO0dcOraRLaQ==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.1.tgz",
+            "integrity": "sha512-gSt2WhLNgEeLstcweQOSp+C+MhOpTsgdNXRqr3zP6M+BUBZ8Md9OU2BYwUYsALBxHza7hwaIWtFHjQ/aOOychw==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.27.2",
+                "@shikijs/types": "1.29.1",
                 "@shikijs/vscode-textmate": "^10.0.1"
             }
         },
         "node_modules/@shikijs/langs": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.27.2.tgz",
-            "integrity": "sha512-MSrknKL0DbeXvhtSigMLIzjPOOQfvK7fsbcRv2NUUB0EvuTTomY8/U+lAkczYrXY2+dygKOapJKk8ScFYbtoNw==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.1.tgz",
+            "integrity": "sha512-iERn4HlyuT044/FgrvLOaZgKVKf3PozjKjyV/RZ5GnlyYEAZFcgwHGkYboeBv2IybQG1KVS/e7VGgiAU4JY2Gw==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.27.2"
+                "@shikijs/types": "1.29.1"
             }
         },
         "node_modules/@shikijs/themes": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.27.2.tgz",
-            "integrity": "sha512-Yw/uV7EijjWavIIZLoWneTAohcbBqEKj6XMX1bfMqO3llqTKsyXukPp1evf8qPqzUHY7ibauqEaQchhfi857mg==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.1.tgz",
+            "integrity": "sha512-lb11zf72Vc9uxkl+aec2oW1HVTHJ2LtgZgumb4Rr6By3y/96VmlU44bkxEb8WBWH3RUtbqAJEN0jljD9cF7H7g==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "1.27.2"
+                "@shikijs/types": "1.29.1"
             }
         },
         "node_modules/@shikijs/types": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.27.2.tgz",
-            "integrity": "sha512-DM9OWUyjmdYdnKDpaGB/GEn9XkToyK1tqxuqbmc5PV+5K8WjjwfygL3+cIvbkSw2v1ySwHDgqATq/+98pJ4Kyg==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.1.tgz",
+            "integrity": "sha512-aBqAuhYRp5vSir3Pc9+QPu9WESBOjUo03ao0IHLC4TyTioSsp/SkbAZSrIH4ghYYC1T1KTEpRSBa83bas4RnPA==",
             "license": "MIT",
             "dependencies": {
                 "@shikijs/vscode-textmate": "^10.0.1",
@@ -2158,9 +2130,9 @@
             }
         },
         "node_modules/astro": {
-            "version": "5.1.7",
-            "resolved": "https://registry.npmjs.org/astro/-/astro-5.1.7.tgz",
-            "integrity": "sha512-hGYHtO+67ZWDl0TY9ysh2iBv2KOgcgvpFJaMGZvknqBjh6TGqrwtWldCsJr1CK57rK8ycpPwC3Bi5bPaBELMuw==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/astro/-/astro-5.1.8.tgz",
+            "integrity": "sha512-7fNNceI/dXqGIkkZQjxhH31alAfgf33cDv34cPLCGFVSHHOpYG0NSrofnxdYf0BvWRlddqkq393UqDM5cJlv1w==",
             "license": "MIT",
             "dependencies": {
                 "@astrojs/compiler": "^2.10.3",
@@ -2206,14 +2178,14 @@
                 "prompts": "^2.4.2",
                 "rehype": "^13.0.2",
                 "semver": "^7.6.3",
-                "shiki": "^1.26.2",
+                "shiki": "^1.29.1",
                 "tinyexec": "^0.3.2",
                 "tsconfck": "^3.1.4",
                 "ultrahtml": "^1.5.3",
                 "unist-util-visit": "^5.0.0",
                 "unstorage": "^1.14.4",
                 "vfile": "^6.0.3",
-                "vite": "^6.0.7",
+                "vite": "^6.0.9",
                 "vitefu": "^1.0.5",
                 "which-pm": "^3.0.0",
                 "xxhash-wasm": "^1.1.0",
@@ -2439,9 +2411,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001692",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
-            "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
+            "version": "1.0.30001695",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001695.tgz",
+            "integrity": "sha512-vHyLade6wTgI2u1ec3WQBxv+2BrTERV28UXQu9LO6lZ9pYeMk34vjXFLOxo1A4UBA8XTL4njRQZdno/yYaSmWw==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2521,27 +2493,18 @@
             }
         },
         "node_modules/chokidar": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
             "license": "MIT",
             "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
+                "readdirp": "^4.0.1"
             },
             "engines": {
-                "node": ">= 8.10.0"
+                "node": ">= 14.16.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
             }
         },
         "node_modules/ci-info": {
@@ -2970,9 +2933,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.83",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
-            "integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
+            "version": "1.5.84",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.84.tgz",
+            "integrity": "sha512-I+DQ8xgafao9Ha6y0qjHHvpZ9OfyA1qKlkHkjywxzniORU2awxyz7f/iVJcULmrF2yrM3nHQf+iDjJtbbexd/g==",
             "license": "ISC"
         },
         "node_modules/emmet": {
@@ -3573,9 +3536,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.5.tgz",
-            "integrity": "sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
             "funding": [
                 {
                     "type": "github",
@@ -4990,9 +4953,9 @@
             }
         },
         "node_modules/micromark-extension-gfm-table": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
-            "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
             "license": "MIT",
             "dependencies": {
                 "devlop": "^1.0.0",
@@ -5719,9 +5682,9 @@
             }
         },
         "node_modules/node-fetch-native": {
-            "version": "1.6.4",
-            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
-            "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==",
+            "version": "1.6.6",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
+            "integrity": "sha512-8Mc2HhqPdlIfedsuZoc3yioPuzp6b+L5jRCRY1QzuWZh2EGJVQrGppC6V6cF0bLdbW0+O2YpqCA25aF/1lvipQ==",
             "license": "MIT"
         },
         "node_modules/node-releases": {
@@ -5784,9 +5747,9 @@
             "license": "MIT"
         },
         "node_modules/oniguruma-to-es": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.1.0.tgz",
-            "integrity": "sha512-Iq/949c5IueVC5gQR7OYXs0uHsDIePcgZFlVRIVGfQcWwbKG+nsyWfthswdytShlRdkZADY+bWSi+BRyUL81gA==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.2.0.tgz",
+            "integrity": "sha512-EEsso27ri0sf+t4uRFEj5C5gvXQj0d0w1Y2qq06b+hDLBnvzO1rWTwEW4C7ytan6nhg4WPwE26eLoiPhHUbvKg==",
             "license": "MIT",
             "dependencies": {
                 "emoji-regex-xs": "^1.0.0",
@@ -6224,17 +6187,16 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+            "version": "2.8.7",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "bin": {
-                "prettier": "bin/prettier.cjs"
+                "prettier": "bin-prettier.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=10.13.0"
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -6317,27 +6279,16 @@
             }
         },
         "node_modules/readdirp": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-            "license": "MIT",
-            "dependencies": {
-                "picomatch": "^2.2.1"
-            },
-            "engines": {
-                "node": ">=8.10.0"
-            }
-        },
-        "node_modules/readdirp/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+            "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
             "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">= 14.18.0"
             },
             "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/recma-build-jsx": {
@@ -6722,9 +6673,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.30.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
-            "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
+            "version": "4.31.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.31.0.tgz",
+            "integrity": "sha512-9cCE8P4rZLx9+PjoyqHLs31V9a9Vpvfo4qNcs6JCiGWYhw2gijSetFbH6SSy1whnkgcefnUwr8sad7tgqsGvnw==",
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "1.0.6"
@@ -6737,25 +6688,25 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.30.1",
-                "@rollup/rollup-android-arm64": "4.30.1",
-                "@rollup/rollup-darwin-arm64": "4.30.1",
-                "@rollup/rollup-darwin-x64": "4.30.1",
-                "@rollup/rollup-freebsd-arm64": "4.30.1",
-                "@rollup/rollup-freebsd-x64": "4.30.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.30.1",
-                "@rollup/rollup-linux-arm64-musl": "4.30.1",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.30.1",
-                "@rollup/rollup-linux-x64-gnu": "4.30.1",
-                "@rollup/rollup-linux-x64-musl": "4.30.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.30.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.30.1",
-                "@rollup/rollup-win32-x64-msvc": "4.30.1",
+                "@rollup/rollup-android-arm-eabi": "4.31.0",
+                "@rollup/rollup-android-arm64": "4.31.0",
+                "@rollup/rollup-darwin-arm64": "4.31.0",
+                "@rollup/rollup-darwin-x64": "4.31.0",
+                "@rollup/rollup-freebsd-arm64": "4.31.0",
+                "@rollup/rollup-freebsd-x64": "4.31.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.31.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.31.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.31.0",
+                "@rollup/rollup-linux-arm64-musl": "4.31.0",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.31.0",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.31.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.31.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.31.0",
+                "@rollup/rollup-linux-x64-gnu": "4.31.0",
+                "@rollup/rollup-linux-x64-musl": "4.31.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.31.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.31.0",
+                "@rollup/rollup-win32-x64-msvc": "4.31.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -6862,17 +6813,17 @@
             }
         },
         "node_modules/shiki": {
-            "version": "1.27.2",
-            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.27.2.tgz",
-            "integrity": "sha512-QtA1C41oEVixKog+V8I3ia7jjGls7oCZ8Yul8vdHrVBga5uPoyTtMvFF4lMMXIyAZo5A5QbXq91bot2vA6Q+eQ==",
+            "version": "1.29.1",
+            "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.1.tgz",
+            "integrity": "sha512-TghWKV9pJTd/N+IgAIVJtr0qZkB7FfFCUrrEJc0aRmZupo3D1OCVRknQWVRVA7AX/M0Ld7QfoAruPzr3CnUJuw==",
             "license": "MIT",
             "dependencies": {
-                "@shikijs/core": "1.27.2",
-                "@shikijs/engine-javascript": "1.27.2",
-                "@shikijs/engine-oniguruma": "1.27.2",
-                "@shikijs/langs": "1.27.2",
-                "@shikijs/themes": "1.27.2",
-                "@shikijs/types": "1.27.2",
+                "@shikijs/core": "1.29.1",
+                "@shikijs/engine-javascript": "1.29.1",
+                "@shikijs/engine-oniguruma": "1.29.1",
+                "@shikijs/langs": "1.29.1",
+                "@shikijs/themes": "1.29.1",
+                "@shikijs/types": "1.29.1",
                 "@shikijs/vscode-textmate": "^10.0.1",
                 "@types/hast": "^3.0.4"
             }
@@ -7169,6 +7120,42 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tailwindcss/node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
         "node_modules/tailwindcss/node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -7179,6 +7166,30 @@
             },
             "engines": {
                 "node": ">=10.13.0"
+            }
+        },
+        "node_modules/tailwindcss/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tailwindcss/node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
             }
         },
         "node_modules/thenify": {
@@ -7370,9 +7381,9 @@
             }
         },
         "node_modules/type-fest": {
-            "version": "4.32.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.32.0.tgz",
-            "integrity": "sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==",
+            "version": "4.33.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.33.0.tgz",
+            "integrity": "sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==",
             "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=16"
@@ -7693,6 +7704,54 @@
                 }
             }
         },
+        "node_modules/unstorage/node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "license": "MIT",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/unstorage/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/unstorage/node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "license": "MIT",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
@@ -7772,9 +7831,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.0.7",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.7.tgz",
-            "integrity": "sha512-RDt8r/7qx9940f8FcOIAH9PTViRrghKaK2K1jY3RaAURrEUbm9Du1mJ72G+jlhtG3WwodnfzY8ORQZbBavZEAQ==",
+            "version": "6.0.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
+            "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
             "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.24.2",
@@ -8328,22 +8387,6 @@
             },
             "optionalDependencies": {
                 "prettier": "2.8.7"
-            }
-        },
-        "node_modules/yaml-language-server/node_modules/prettier": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
-            "license": "MIT",
-            "optional": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/yaml-language-server/node_modules/request-light": {

--- a/portfolio/web/package.json
+++ b/portfolio/web/package.json
@@ -13,11 +13,11 @@
     },
     "dependencies": {
         "@astrojs/check": "^0.9.4",
-        "@astrojs/mdx": "^4.0.6",
+        "@astrojs/mdx": "^4.0.7",
         "@astrojs/sitemap": "^3.2.1",
-        "@astrojs/tailwind": "^5.1.4",
+        "@astrojs/tailwind": "^5.1.5",
         "@fortawesome/fontawesome-free": "^6.7.2",
-        "astro": "^5.1.7",
+        "astro": "^5.1.8",
         "astro-i18next": "^1.0.0-beta.21",
         "tailwindcss": "^3.4.17",
         "three": "^0.172.0"

--- a/portfolio/web/playwright.config.ts
+++ b/portfolio/web/playwright.config.ts
@@ -32,17 +32,11 @@ export default defineConfig({
     trace: 'on-first-retry',
 
     /* Augmenter les timeouts */
-    actionTimeout: 15000,
-    navigationTimeout: 30000,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
   },
 
-  timeout: 60000, // Timeout global de 60 secondes
-
-  /* Configure environment variables for testing */
-  env: {
-    MODE: 'test',
-    PUBLIC_API_URL: 'http://localhost:8080'
-  },
+  timeout: 60_000, // Timeout global de 60 secondes
 
   /* Configure projects for major browsers */
   projects: [
@@ -87,7 +81,7 @@ export default defineConfig({
     command: 'npm run dev',
     url: 'http://localhost:4321',
     reuseExistingServer: !process.env.CI,
-    timeout: 120000, // 2 minutes pour le démarrage du serveur
+    timeout: 120_000, // 2 minutes pour le démarrage du serveur
     stdout: 'pipe',
     stderr: 'pipe',
   },

--- a/portfolio/web/src/components/common/Modal.astro
+++ b/portfolio/web/src/components/common/Modal.astro
@@ -18,7 +18,11 @@ const {
 } = Astro.props;
 ---
 
-<dialog id={id} class:list={["modal", `modal--${size}`, className]}>
+<dialog
+    id={id}
+    class:list={["modal", `modal--${size}`, className]}
+    {...closeOnClickOutside && { "data-close-on-click-outside": "" }}
+>
     <div class="modal-content">
         {
             showCloseButton && (
@@ -59,7 +63,9 @@ const {
         constructor(modal: HTMLDialogElement) {
             this.modal = modal;
             this.closeButton = modal.querySelector("[data-close-modal]");
-            this.closeOnClickOutside = true;
+            this.closeOnClickOutside = modal.hasAttribute(
+                "data-close-on-click-outside"
+            );
             this.init();
         }
 
@@ -69,6 +75,8 @@ const {
             }
 
             this.modal.addEventListener("click", (e) => {
+                if (!this.closeOnClickOutside) return;
+
                 const rect = this.modal.getBoundingClientRect();
                 const isInDialog =
                     e.clientX >= rect.left &&

--- a/portfolio/web/src/components/sections/RssFeeds.astro
+++ b/portfolio/web/src/components/sections/RssFeeds.astro
@@ -54,7 +54,9 @@ const itemsWithDateObjects = items.map((item) => ({
 
     let currentPage = 1;
     let isLoading = false;
-    const loadMoreBtn = document.getElementById("loadMore") as HTMLButtonElement | null;
+    const loadMoreBtn = document.getElementById(
+        "loadMore"
+    ) as HTMLButtonElement | null;
     const articlesContainer = document.querySelector(".articles-grid");
 
     function formatArticleDate(item: RssItem): string {
@@ -62,7 +64,7 @@ const itemsWithDateObjects = items.map((item) => ({
         return date.toLocaleDateString("fr-FR", {
             year: "numeric",
             month: "long",
-            day: "numeric"
+            day: "numeric",
         });
     }
 
@@ -71,7 +73,7 @@ const itemsWithDateObjects = items.map((item) => ({
             <article class="bg-secondary rounded-lg overflow-hidden shadow-md hover:shadow-xl transition-all duration-300 hover:-translate-y-1">
                 <div class="relative h-48 overflow-hidden">
                     <img
-                        src="${item.image_url || item.imageUrl || 'https://placehold.co/600x400'}"
+                        src="${item.image_url || item.imageUrl || "https://placehold.co/600x400"}"
                         alt="${item.title}"
                         loading="lazy"
                         class="w-full h-full object-cover transition-transform duration-300 hover:scale-105"
@@ -86,7 +88,7 @@ const itemsWithDateObjects = items.map((item) => ({
                     </p>
                     <p class="text-base text-text mb-6 line-clamp-3">${item.description}</p>
                     <a
-                        href="${item.url || item.link || '#'}"
+                        href="${item.url || item.link || "#"}"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="inline-block text-primary font-semibold hover:text-primary-dark transition-colors duration-300"
@@ -107,14 +109,17 @@ const itemsWithDateObjects = items.map((item) => ({
             loadMoreBtn.disabled = true;
             loadMoreBtn.textContent = "Chargement...";
 
-            const API_URL = import.meta.env.PUBLIC_API_URL || "http://localhost:8080";
-            const response = await fetch(`${API_URL}/api/rss?page=${currentPage + 1}&limit=9`);
+            const API_URL =
+                import.meta.env.PUBLIC_API_URL || "http://localhost:8080";
+            const response = await fetch(
+                `${API_URL}/api/rss?page=${currentPage + 1}&limit=9`
+            );
 
             if (!response.ok) {
                 throw new Error(`Erreur HTTP: ${response.status}`);
             }
 
-            const newItems = await response.json() as RssItem[];
+            const newItems = (await response.json()) as RssItem[];
 
             if (!Array.isArray(newItems) || newItems.length === 0) {
                 loadMoreBtn.textContent = "Plus d'articles disponibles";
@@ -124,13 +129,15 @@ const itemsWithDateObjects = items.map((item) => ({
 
             // Ajouter les nouveaux articles
             for (const item of newItems) {
-                articlesContainer.insertAdjacentHTML("beforeend", createArticleHtml(item));
+                articlesContainer.insertAdjacentHTML(
+                    "beforeend",
+                    createArticleHtml(item)
+                );
             }
 
             currentPage++;
             loadMoreBtn.textContent = "Charger plus d'articles";
             loadMoreBtn.disabled = false;
-
         } catch (error) {
             console.error("Erreur:", error);
             loadMoreBtn.textContent = "Erreur lors du chargement";

--- a/portfolio/web/src/scripts/fireflies.ts
+++ b/portfolio/web/src/scripts/fireflies.ts
@@ -36,7 +36,7 @@ export class FirefliesAnimation {
       alpha: true,
       antialias: true
     });
-    this.renderer.setClearColor(0x000000, 0);
+    this.renderer.setClearColor(0x00_00_00, 0);
     this.renderer.setSize(window.innerWidth, window.innerHeight);
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
   }


### PR DESCRIPTION

- Upgraded several dependencies to their latest versions, including:
  - @astrojs/mdx from 4.0.6 to 4.0.7
  - @astrojs/tailwind from 5.1.4 to 5.1.5
  - astro from 5.1.7 to 5.1.8
  - shiki from 1.26.2 to 1.29.1
  - vite from 6.0.7 to 6.0.11
  - caniuse-lite from 1.0.30001692 to 1.0.30001695
  - prettier from 3.4.2 to 2.8.7
  - various other packages including chokidar, readdirp, and oniguruma-to-es.

These updates improve performance, security, and compatibility with the latest features in the respective libraries.